### PR TITLE
mainnet: limit docker log size and files

### DIFF
--- a/.contrib/docker-compose.yaml-mainnet
+++ b/.contrib/docker-compose.yaml-mainnet
@@ -39,6 +39,11 @@ services:
     volumes:
       - ./config:/srv/aurora/relayer/config
     entrypoint: ["node", "lib/index.js"]
+    logging:
+      driver: "json-file"
+      options:
+        max-file: 5
+        max-size: "10m"
   nearcore:
     image: nearaurora/nearcore:mainnet
     restart: unless-stopped


### PR DESCRIPTION
In practice, the `endpoint` service produces a large number of RPC access logs, and this is done to limit docker logs to prevent infinite log growth.